### PR TITLE
Introduce the 'discovery' resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,12 +9,13 @@ driver:
   name: vagrant # provide a default test-kitchen driver, vagrant
 
 driver_config:
-  require_chef_omnibus: latest
+  require_chef_omnibus: true
 
 provisioner:
   name: chef_zero
   client_rb:
     environment: _default
+  nodes_path: './test/fixtures/nodes'
   attributes:
     openssh:
       server:
@@ -47,12 +48,14 @@ platforms:
   - name: ubuntu-12.04
     run_list:
     - recipe[apt]
-  - name: centos-6.5
+  - name: centos-6.6
     run_list:
     - recipe[yum]
 
 suites:
   - name: default
-    run_list: recipe[search_helpers]
-    attributes:
-      foo: 'bar'
+    run_list:
+      - recipe[test_discovery::add]
+      - recipe[test_discovery::remove]
+      - recipe[test_discovery::default]
+      - recipe[test_discovery::compile_time]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,19 @@ WordArray:
 UnusedBlockArgument:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/PerceivedComplexity:
+  Max: 15
+
+# Configuration parameters: EnforcedStyle, SupportedStyles.
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
 AllCops:
   Include:
     - '**/metadata.rb'

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.getchef.com'
 
 metadata
+
+group :integration do
+  cookbook 'test_discovery', :path => 'test/fixtures/cookbooks/test_discovery'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ end
 group :unit do
   gem 'berkshelf', '~> 3'
   gem 'chefspec'
+  gem 'chef-sugar'
+  gem 'chef', '~> 12.1'
 end
 
 group :kitchen_common do

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Rackspace US, Inc.
+Copyright (c) 2015 Rackspace US, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,15 @@
+if defined?(ChefSpec)
+  ChefSpec.define_matcher(:discovery)
+
+  def search_discovery(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:discovery, :search, resource)
+  end
+
+  def add_discovery(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:discovery, :add, resource)
+  end
+
+  def remove_discovery(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:discovery, :remove, resource)
+  end
+end

--- a/libraries/provider_search_discovery.rb
+++ b/libraries/provider_search_discovery.rb
@@ -1,0 +1,71 @@
+class Chef
+  class Provider::Discovery < Provider
+    include Poise
+
+    def action_search
+      converge_by("search #{new_resource.name}") do
+        notifying_block do
+          # initial setup & validation
+          sanity_checks
+
+          # figure out query and returned key
+          query = new_resource.tags.map { |t| "tags:#{t}" }.join(' AND ')
+          run_state = "discovery_#{new_resource.name}"
+          node.run_state[run_state] = []
+
+          # run the actual search and process results
+          Chef::Search::Query.new.search(:node, query) do |i|
+            # we must filter to avoid nested tags that come back from search but aren't at the top level
+            next unless i['tags'] # skip results that have no tags
+
+            # set skip to true if a required tag is missing for this node
+            skip = false
+            new_resource.tags.each do |t|
+              skip = true unless i['tags'].include?(t)
+            end
+            next if skip
+
+            # temporarily hold onto i
+            obj = i
+            if new_resource.block
+              ret = new_resource.block.call(i)
+
+              # if the block returns something interesting, use it!
+              obj = ret if ret
+            end
+            node.run_state[run_state] << obj
+          end
+        end
+      end
+    end
+
+    def action_add
+      converge_by("add #{new_resource.name}") do
+        notifying_block do
+          sanity_checks
+          new_resource.tags.each do |t|
+            node.tag(t)
+          end
+        end
+      end
+    end
+
+    def action_remove
+      converge_by("remove #{new_resource.name}") do
+        notifying_block do
+          sanity_checks
+          new_resource.tags.each do |t|
+            node.normal[:tags].delete(t)
+          end
+        end
+      end
+    end
+
+    private
+
+    def sanity_checks
+      return unless Chef::Config[:solo]
+      fail 'Cannot use search_discovery with chef_solo, please guard in your recipe'
+    end
+  end
+end

--- a/libraries/resource_search_discovery.rb
+++ b/libraries/resource_search_discovery.rb
@@ -1,0 +1,10 @@
+class Chef
+  class Resource::Discovery < Resource
+    include Poise
+
+    actions(:search, :add, :remove)
+
+    attribute(:tags, kind_of: Array, default: [])
+    attribute(:block, kind_of: Proc, default: nil)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'apt'
+depends 'poise'
 depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,8 +3,6 @@
 # Cookbook Name:: search_helpers
 # Recipe:: default
 #
-# Copyright 2014, Rackspace
+# Copyright 2015, Rackspace
 #
-node.default['example']['attribute'] = 'lions, tigers'
-node.override['example']['attribute'] = 'lions, tigers and bears'
-log node['example']['attribute']
+Chef::Log.warn('search_helpers::default was included but does not do anything.')

--- a/test/fixtures/cookbooks/test_discovery/metadata.rb
+++ b/test/fixtures/cookbooks/test_discovery/metadata.rb
@@ -1,0 +1,5 @@
+name 'test_discovery'
+version '0.1.0'
+
+depends 'chef-sugar'
+depends 'search_helpers'

--- a/test/fixtures/cookbooks/test_discovery/recipes/add.rb
+++ b/test/fixtures/cookbooks/test_discovery/recipes/add.rb
@@ -1,0 +1,4 @@
+discovery 'make a slave' do
+  tags ['mysql', 'slave']
+  action :add
+end

--- a/test/fixtures/cookbooks/test_discovery/recipes/compile_time.rb
+++ b/test/fixtures/cookbooks/test_discovery/recipes/compile_time.rb
@@ -1,0 +1,18 @@
+include_recipe 'chef-sugar'
+
+discovery 'find a redis sentinel' do
+  tags ['redis', 'sentinel']
+  block do |node|
+    node_ip = best_ip_for(node)
+    Chef::Log.warn("#{node.name} was found as a redis sentinel at #{node_ip}")
+    node_ip
+  end
+  action :nothing
+end.run_action(:search) # now we're at compile time!
+
+# since we ran the action at compile time, we have this data available,
+# but this won't work in a unit test where discovery isn't stepped into
+if node.run_state && node.run_state['discovery_find a redis sentinel']
+  rs = node.run_state['discovery_find a redis sentinel']
+  Chef::Log.warn("All nodes found: #{rs.join(',')}") if rs
+end

--- a/test/fixtures/cookbooks/test_discovery/recipes/default.rb
+++ b/test/fixtures/cookbooks/test_discovery/recipes/default.rb
@@ -1,0 +1,20 @@
+include_recipe 'chef-sugar'
+
+discovery 'find a mysql master' do
+  tags ['master', 'mysql']
+  block do |node|
+    node_ip = best_ip_for(node)
+    Chef::Log.warn("#{node.name} was found as a mysql master at #{node_ip}")
+    node_ip
+  end
+  action :search
+end
+
+# note that in this scope at compile time, node.run_state is not populated yet,
+# because chef provider actions don't actually run until convergence!
+
+ruby_block 'log all nodes' do
+  block do
+    Chef::Log.warn("All nodes found: #{node.run_state['discovery_find a mysql master'].join(',')}")
+  end
+end

--- a/test/fixtures/cookbooks/test_discovery/recipes/not_found.rb
+++ b/test/fixtures/cookbooks/test_discovery/recipes/not_found.rb
@@ -1,0 +1,7 @@
+discovery 'please dont exist' do
+  tags ['florida', 'gainesville']
+  block do |node|
+    node.run_state['test-kitchen-search-helpers-shouldntexist'] = true
+  end
+  action :search
+end

--- a/test/fixtures/cookbooks/test_discovery/recipes/remove.rb
+++ b/test/fixtures/cookbooks/test_discovery/recipes/remove.rb
@@ -1,0 +1,4 @@
+discovery 'add and remove' do
+  tags ['foo', 'mysql']
+  action [:add, :remove]
+end

--- a/test/fixtures/nodes/node01.json
+++ b/test/fixtures/nodes/node01.json
@@ -1,0 +1,30 @@
+{
+  "name": "node01",
+  "chef_environment": "_default",
+  "json_class": "Chef::Node",
+  "automatic": {
+    "hostname": "vagrant.vm",
+    "os": "centos",
+    "recipes": [
+      "default::default"
+    ],
+    "roles": [
+      "default_role"
+    ],
+    "tags": [
+      "mysql",
+      "mysql_master"
+    ],
+    "ipaddress": "192.168.0.23"
+  },
+  "normal": {
+  },
+  "chef_type": "node",
+  "default": {
+  },
+  "override": {
+  },
+  "run_list": [
+    "role[database_master]"
+  ]
+}

--- a/test/fixtures/nodes/node02.json
+++ b/test/fixtures/nodes/node02.json
@@ -1,0 +1,30 @@
+{
+  "name": "node02",
+  "chef_environment": "_default",
+  "json_class": "Chef::Node",
+  "automatic": {
+    "hostname": "vagrant.vm",
+    "os": "centos",
+    "recipes": [
+      "default::default"
+    ],
+    "roles": [
+      "default_role"
+    ],
+    "tags": [
+      "redis",
+      "redis_sentinel"
+    ],
+    "ipaddress": "192.168.0.24"
+  },
+  "normal": {
+  },
+  "chef_type": "node",
+  "default": {
+  },
+  "override": {
+  },
+  "run_list": [
+    "role[redis_sentinel]"
+  ]
+}

--- a/test/fixtures/platform/centos/6.5.json
+++ b/test/fixtures/platform/centos/6.5.json
@@ -1,6 +1,0 @@
-{
-  "platform": "centos",
-  "platform_family": "rhel",
-  "platform_version": "6.5",
-  "version": "6.5"
-}

--- a/test/fixtures/platform/ubuntu/12.04.json
+++ b/test/fixtures/platform/ubuntu/12.04.json
@@ -1,9 +1,0 @@
-{
-  "platform": "ubuntu",
-  "platform_family": "debian",
-  "platform_version": "12.04",
-  "version": "12.04",
-  "lsb": {
-    "codename": "precise"
-  }
-}

--- a/test/fixtures/platform/ubuntu/14.04.json
+++ b/test/fixtures/platform/ubuntu/14.04.json
@@ -1,9 +1,0 @@
-{
-  "platform": "ubuntu",
-  "platform_family": "debian",
-  "platform_version": "14.04",
-  "version": "14.04",
-  "lsb": {
-    "codename": "trusty"
-  }
-}

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,6 +2,11 @@
 
 require_relative 'spec_helper'
 
-describe 'default' do
-  it { skip 'write some tests' }
+describe command('uname') do
+  its(:stdout) { should match(/Linux/) }
 end
+
+# we don't do much testing here. the chefspec tests exercise the entire
+# functionality, and already use a chef-zero (in memory) chef server. We don't
+# get anything extra with real servers being spun up (and we aren't modifying
+# the servers), so there's not much really worth testing except convergence.

--- a/test/unit/spec/add_spec.rb
+++ b/test/unit/spec/add_spec.rb
@@ -1,0 +1,10 @@
+require_relative 'spec_helper'
+
+describe 'test_discovery::add' do
+  let(:chef_run) { ChefSpec::ServerRunner.new(step_into: ['discovery']).converge(described_recipe) }
+
+  it 'should tag the node as mysql slave' do
+    expect(chef_run).to add_discovery('make a slave')
+    expect(chef_run.node['tags']).to eq(['mysql', 'slave'])
+  end
+end

--- a/test/unit/spec/compile_time_spec.rb
+++ b/test/unit/spec/compile_time_spec.rb
@@ -1,0 +1,17 @@
+require_relative 'spec_helper'
+
+describe 'test_discovery::compile_time' do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(step_into: ['discovery']) do |node, server|
+      n = stub_node(platform: 'ubuntu', version: '12.04') do |stubnode|
+        stubnode.set['tags'] = ['redis', 'sentinel']
+      end
+      server.create_node(n)
+    end.converge(described_recipe)
+  end
+
+  it 'should search for a redis sentinel' do
+    expect(chef_run).to search_discovery('find a redis sentinel')
+    expect(chef_run.node.run_state['discovery_find a redis sentinel']).to eq(['10.0.0.2'])
+  end
+end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -1,26 +1,21 @@
-# Encoding: utf-8
-
 require_relative 'spec_helper'
 
-# this will pass on search_helpers, fail elsewhere, forcing you to
-# write those chefspec tests you always were avoiding
-describe 'search_helpers::default' do
-  before { stub_resources }
-  supported_platforms.each do |platform, versions|
-    versions.each do |version|
-      context "on #{platform.capitalize} #{version}" do
-        let(:chef_run) do
-          ChefSpec::ServerRunner.new(platform: platform, version: version) do |node|
-            node_resources(node)
-          end.converge(described_recipe)
-        end
+# Use these to debug resource names and classes on the chef run
+# pp chef_run.resource_collection.map(&:name).join(',')
+# pp chef_run.resource_collection.map(&:class).join(',')
 
-        property = load_platform_properties(platform: platform, platform_version: version)
-
-        it "#{property} chefspec must converge" do
-          expect(chef_run).to be_truthy
-        end
+describe 'test_discovery::default' do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(step_into: ['discovery']) do |node, server|
+      n = stub_node(platform: 'ubuntu', version: '12.04') do |stubnode|
+        stubnode.set['tags'] = ['mysql', 'master']
       end
-    end
+      server.create_node(n)
+    end.converge(described_recipe)
+  end
+
+  it 'should search for a mysql master' do
+    expect(chef_run).to search_discovery('find a mysql master')
+    expect(chef_run.node.run_state['discovery_find a mysql master']).to eq(['10.0.0.2'])
   end
 end

--- a/test/unit/spec/not_found_spec.rb
+++ b/test/unit/spec/not_found_spec.rb
@@ -1,0 +1,10 @@
+require_relative 'spec_helper'
+
+describe 'test_discovery::not_found' do
+  let(:chef_run) { ChefSpec::ServerRunner.new(step_into: ['discovery']).converge(described_recipe) }
+
+  it 'should not find anything' do
+    expect(chef_run).to search_discovery('please dont exist')
+    expect(chef_run.node.run_state['discovery_please dont exist']).to be_empty # not falsey or nil, empty!
+  end
+end

--- a/test/unit/spec/remove_spec.rb
+++ b/test/unit/spec/remove_spec.rb
@@ -1,0 +1,15 @@
+require_relative 'spec_helper'
+
+describe 'test_discovery::remove' do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(step_into: ['discovery']) do |node, server|
+      node.tag('mysql', 'foo')
+    end.converge(described_recipe)
+  end
+
+  it 'should tag and untag the node as mysql and slave' do
+    expect(chef_run).to add_discovery('add and remove')
+    expect(chef_run).to remove_discovery('add and remove')
+    expect(chef_run.node.tags).to be_empty
+  end
+end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -1,23 +1,4 @@
-# Encoding: utf-8
-require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'chef/application'
-require 'json'
-
-Dir['./test/unit/spec/support/**/*.rb'].sort.each { |f| require f }
-
-::LOG_LEVEL = :fatal
-::CHEFSPEC_OPTS = {
-  log_level: ::LOG_LEVEL
-}
-
-def node_resources(node)
-  node.automatic['example']['attribute'] = 'lions, tigers and bears!'
-end
-
-def stub_resources
-  stub_command('which sudo').and_return('/usr/bin/sudo')
-end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/test/unit/spec/support/platform_properties.rb
+++ b/test/unit/spec/support/platform_properties.rb
@@ -1,9 +1,0 @@
-require 'json'
-
-def load_platform_properties(args)
-  platform_file_str = "../../../fixtures/platform/#{args[:platform]}/#{args[:platform_version]}.json"
-  platform_file_name = File.join(File.dirname(__FILE__), platform_file_str)
-  platform_str = '{}'
-  platform_str = IO.read(platform_file_name) if File.exist?(platform_file_name)
-  JSON.parse(platform_str, symbolize_names: true)
-end

--- a/test/unit/spec/support/supported_platforms.rb
+++ b/test/unit/spec/support/supported_platforms.rb
@@ -1,6 +1,0 @@
-def supported_platforms
-  {
-    'ubuntu' => ['12.04', '14.04'],
-    'centos' => ['6.5']
-  }
-end

--- a/test/unit/spec/warn_spec.rb
+++ b/test/unit/spec/warn_spec.rb
@@ -1,0 +1,1 @@
+# we aren't going to test that a log message is emitted.


### PR DESCRIPTION
Please see the README for an explanation of the discovery resource. It is intended to provide a point of indirection on top of Chef search that we use today. We could later change out the backend to be consul, etcd, or even just node attributes or DNS.
