### PR TITLE
Add require for poise

### DIFF
--- a/libraries/provider_search_discovery.rb
+++ b/libraries/provider_search_discovery.rb
@@ -1,3 +1,5 @@
+require 'poise'
+
 class Chef
   class Provider::Discovery < Provider
     include Poise

--- a/libraries/resource_search_discovery.rb
+++ b/libraries/resource_search_discovery.rb
@@ -1,3 +1,5 @@
+require 'poise'
+
 class Chef
   class Resource::Discovery < Resource
     include Poise


### PR DESCRIPTION
To make compatible with the most recent version of poise, add `require 'poise'` before using `include Poise`.
